### PR TITLE
correction to CleanWebpackPlugin call

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -194,7 +194,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-+     new CleanWebpackPlugin(['dist/*']),
++     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'
       })


### PR DESCRIPTION
CleanWebpackPlugin() does not accept array as argument any more. The argument is 'options'. However there is no need to pass the output folder, since the plugin picks the output folders from webpack config. The current call (with the array argument) throws an error.


